### PR TITLE
Fix HTML-templating om compatibel te zijn met Apps Script

### DIFF
--- a/HTML_BESTANDENINFO.md
+++ b/HTML_BESTANDENINFO.md
@@ -1,0 +1,55 @@
+# HTML-bestandenconventie voor Huisarts Check
+
+Dit document beschrijft hoe HTML-bestanden moeten worden genoemd en georganiseerd binnen dit Apps Script project.
+
+## Achtergrond
+
+Google Apps Script ondersteunt geen fysieke mappenstructuur zoals in een traditioneel bestandssysteem. Alle bestanden worden "plat" in het project opgeslagen, zonder submappen. Dit betekent dat verwijzingen naar bestanden zoals `HtmlTemplates/Dashboard.html` niet direct werken binnen Apps Script.
+
+## Naamgevingsconventie
+
+Om dit probleem op te lossen, gebruiken we de volgende naamgevingsconventie:
+
+1. Alle HTML-templatebestanden krijgen het voorvoegsel `HTML_` om ze te onderscheiden van andere bestanden.
+2. De oorspronkelijke bestanden uit de `HtmlTemplates` map moeten worden hernoemd volgens dit patroon.
+
+Bijvoorbeeld:
+- `HtmlTemplates/Dashboard.html` → `HTML_Dashboard.html`
+- `HtmlTemplates/Login.html` → `HTML_Login.html`
+- `HtmlTemplates/About.html` → `HTML_About.html`
+
+## Toegang tot HTML-bestanden
+
+Om HTML-bestanden consequent te laden, is er een hulpfunctie `getHtmlTemplate()` toegevoegd aan `UI.gs`. Deze functie zorgt voor het juiste voorvoegsel bij het benaderen van de HTML-templates.
+
+```javascript
+function getHtmlTemplate(templateName) {
+  const htmlPrefix = 'HTML_';
+  return HtmlService.createTemplateFromFile(htmlPrefix + templateName);
+}
+```
+
+Gebruik deze functie als volgt:
+
+```javascript
+// In plaats van
+const template = HtmlService.createTemplateFromFile('HtmlTemplates/Dashboard');
+
+// Gebruik
+const template = getHtmlTemplate('Dashboard');
+```
+
+## Implementatiestappen
+
+Als je het project importeert in Google Apps Script, volg deze stappen:
+
+1. Upload alle HTML-bestanden naar het Apps Script project.
+2. Hernoem de bestanden door `HTML_` toe te voegen aan het begin van elke bestandsnaam.
+3. Verwijder de map `HtmlTemplates/` aangezien deze niet ondersteund wordt.
+
+## Voordelen van deze aanpak
+
+- Duidelijke naamgevingsconventie die aangeeft dat het om HTML-templatebestanden gaat
+- Consistente en duidelijke manier om HTML-templates te laden
+- Vermijdt conflicten met andere bestandsnamen in de platte structuur
+- Maakt het gemakkelijker om nieuwe templates toe te voegen in de toekomst

--- a/UI.gs
+++ b/UI.gs
@@ -8,6 +8,21 @@
  */
 
 /**
+ * Helper functie om HTML templates te laden.
+ * Apps Script ondersteunt geen mappenstructuur, daarom gebruiken we deze functie om HTML-bestanden
+ * consistent te benaderen.
+ * 
+ * @param {string} templateName - De naam van het HTML-template bestand (zonder prefix)
+ * @return {HtmlTemplate} Het HTML-template object
+ */
+function getHtmlTemplate(templateName) {
+  // In Apps Script worden bestanden in een platte structuur opgeslagen,
+  // we geven de bestanden een prefix om ze onderscheidend te maken
+  const htmlPrefix = 'HTML_';
+  return HtmlService.createTemplateFromFile(htmlPrefix + templateName);
+}
+
+/**
  * UI klasse voor het beheren van de gebruikersinterface
  */
 class UIClass {
@@ -36,7 +51,7 @@ class UIClass {
       }
       
       // Laad dashboard template
-      const template = HtmlService.createTemplateFromFile('HtmlTemplates/Dashboard');
+      const template = getHtmlTemplate('Dashboard');
       
       // Geef gebruiker en instellingen door
       template.user = authStatus.user;
@@ -72,7 +87,7 @@ class UIClass {
       }
       
       // Laad settings template
-      const template = HtmlService.createTemplateFromFile('HtmlTemplates/Settings');
+      const template = getHtmlTemplate('Settings');
       
       // Geef gebruiker en instellingen door
       template.user = authStatus.user;
@@ -99,7 +114,7 @@ class UIClass {
       Logger.info('Renderen van login pagina');
       
       // Laad login template
-      const template = HtmlService.createTemplateFromFile('HtmlTemplates/Login');
+      const template = getHtmlTemplate('Login');
       
       // Geef auth URL door
       template.authUrl = authUrl || AuthService.getLoginUrl();
@@ -134,7 +149,7 @@ class UIClass {
       }
       
       // Gebruiker is ingelogd, laad normale UI
-      const template = HtmlService.createTemplateFromFile('HtmlTemplates/Index');
+      const template = getHtmlTemplate('Index');
       
       // Geef gebruikersgegevens door aan client
       template.user = authStatus.user;
@@ -160,7 +175,7 @@ class UIClass {
       Logger.info('Renderen van Over pagina');
       
       // Laad about template
-      const template = HtmlService.createTemplateFromFile('HtmlTemplates/About');
+      const template = getHtmlTemplate('About');
       
       return template.evaluate()
         .setTitle('Over - Huisarts Check')


### PR DESCRIPTION
## Beschrijving
Deze PR implementeert een oplossing voor de HTML-templating structuur in het Apps Script project, zoals beschreven in issue #17. 

Apps Script ondersteunt geen werkelijke mappenstructuur zoals we nu hebben met de `HtmlTemplates/` directory. Deze PR voegt een gestandaardiseerde manier toe om HTML-templates te benaderen die compatibel is met de platte bestandsstructuur van Apps Script.

## Wijzigingen
1. **UI.gs**: Bijgewerkt met een helper functie `getHtmlTemplate()` die een gestandaardiseerde manier biedt om HTML-templates te laden:
   - Verwijdert alle verwijzingen naar `HtmlTemplates/` in de paden
   - Gebruikt een consistent voorvoegsel `HTML_` voor alle templatebestanden
   - Centraal beheer van de naamgevingsconventie

2. **HTML_BESTANDENINFO.md**: Toegevoegd om de nieuwe conventie te documenteren:
   - Uitleg over waarom deze aanpak nodig is
   - Naamgevingsconventie voor HTML-bestanden (`HTML_` voorvoegsel)
   - Instructies voor het implementeren in een Apps Script project
   - Uitleg over het gebruik van de helper functie

## Implementatienotes
Bij het uploaden naar een werkend Apps Script project, moeten de HTML-bestanden worden hernoemd volgens de beschreven conventie:
- `HtmlTemplates/Dashboard.html` → `HTML_Dashboard.html`
- `HtmlTemplates/Login.html` → `HTML_Login.html`
- etc.

## Voordelen
- Gestandaardiseerde manier om HTML-templates te benaderen
- Vermijdt fouten gerelateerd aan de beperkingen van Apps Script
- Makkelijker beheer van templates in de toekomst
- Duidelijke documentatie voor ontwikkelaars

Deze wijzigingen lossen issue #17 op en maken het project klaar voor implementatie in een echt Apps Script omgeving.
