### PR TITLE
Fix: Los probleem met pagina laden en foutmelding op

### DIFF
--- a/HTML_Index.html
+++ b/HTML_Index.html
@@ -291,18 +291,18 @@
     
     <script>
       // Globale variabelen voor template data
-      var user = <?= authStatus && authStatus.loggedIn ? JSON.stringify(user) : 'null' ?>;
+      var user = <?= authStatus && authStatus.loggedIn && authStatus.user ? JSON.stringify(authStatus.user) : 'null' ?>;
       var isAdmin = <?= authStatus && authStatus.isAdmin ? 'true' : 'false' ?>;
-      var authUrl = <?= authStatus && authStatus.authUrl ? '"' + authStatus.authUrl + '"' : 'null' ?>;
-      var errorMessage = <?= authStatus && authStatus.errorMessage ? '"' + authStatus.errorMessage + '"' : 'null' ?>;
+      var authUrl = <?= authStatus && authStatus.authUrl ? '\"' + authStatus.authUrl + '\"' : 'null' ?>;
+      var errorMessage = <?= authStatus && authStatus.errorMessage ? '\"' + authStatus.errorMessage + '\"' : 'null' ?>;
       
       // Als er direct een foutmelding is, toon deze
       if (errorMessage) {
         document.addEventListener('DOMContentLoaded', function() {
           var errorDiv = document.getElementById('error');
-          var errorMessage = document.getElementById('error-message');
-          if (errorDiv && errorMessage) {
-            errorMessage.textContent = errorMessage;
+          var errorMessageElem = document.getElementById('error-message');
+          if (errorDiv && errorMessageElem) {
+            errorMessageElem.textContent = errorMessage;
             errorDiv.style.display = 'block';
           }
         });
@@ -326,6 +326,12 @@
             content.style.display = 'block';
           }
         });
+      }
+      
+      // Diagnostische informatie loggen als beschikbaar
+      var diagnosticInfo = <?= typeof diagnosticInfo !== 'undefined' ? JSON.stringify(diagnosticInfo) : 'null' ?>;
+      if (diagnosticInfo) {
+        console.log('Diagnostische informatie:', diagnosticInfo);
       }
     </script>
     

--- a/HTML_Scripts.html
+++ b/HTML_Scripts.html
@@ -644,6 +644,7 @@
   
   /**
    * Toont een foutmelding
+   * VERBETERD: veiliger omgaan met verschillende foutobjecttypes
    */
   function showError(message) {
     console.error("Foutmelding: " + message);
@@ -653,11 +654,42 @@
     
     if (!errorContainer || !errorMessage) {
       console.error("Error container of message element niet gevonden");
-      alert("Fout: " + message);
+      alert("Fout: " + (message ? message.toString() : "Onbekende fout"));
       return;
     }
     
-    errorMessage.textContent = message;
+    // Veilige string conversie voor verschillende foutobjecttypes
+    let errorText = "Er is een fout opgetreden";
+    
+    if (message) {
+      if (typeof message === 'string') {
+        errorText = message;
+      } else if (message instanceof Error) {
+        errorText = message.message || message.toString();
+      } else if (message instanceof HTMLElement) {
+        // Voorkom dat HTMLElement als [object HTMLElement] wordt weergegeven
+        errorText = "Fout in DOM element: " + message.tagName;
+        try {
+          // Probeer de innerText of textContent te gebruiken indien beschikbaar
+          const elementText = message.innerText || message.textContent;
+          if (elementText) {
+            errorText += " - " + elementText;
+          }
+        } catch (e) {
+          // Negeer fouten bij het ophalen van element tekst
+        }
+      } else {
+        // Probeer object naar string te converteren
+        try {
+          errorText = message.toString();
+        } catch (e) {
+          errorText = "Fout object kon niet worden weergeven";
+        }
+      }
+    }
+    
+    // Zet de foutmelding in het element
+    errorMessage.textContent = errorText;
     errorContainer.style.display = 'block';
     
     // Verberg na 8 seconden


### PR DESCRIPTION
## Beschrijving
Deze pull request lost een bug op in de applicatie waarbij de pagina blijft hangen op "Laden..." en een vreemde foutmelding (`[object HTMLParagraphElement]`) wordt weergegeven.

## Wijzigingen
1. **HTML_Scripts.html**: Verbeterde foutafhandeling in de `showError()` functie
   - Toegevoegd: Robuuste type-detectie voor verschillende soorten foutobjecten
   - Toegevoegd: Specifieke afhandeling voor HTML elementen om te voorkomen dat `[object HTMLElement]` wordt weergegeven
   - Verbeterd: Veiligere string conversie voor alle typen foutmeldingen

2. **HTML_Index.html**: Verbeterde template variabelen initialisatie
   - Toegevoegd: Extra check op aanwezigheid van `authStatus.user` bij het instellen van de user variabele
   - Toegevoegd: Meer robuuste errorMessage verwerking
   - Toegevoegd: Diagnostische logging als deze beschikbaar is

## Oplossing
De hoofdoorzaak van de bug was dat de `showError` functie niet correct omging met HTML elementen, waardoor `[object HTMLParagraphElement]` werd weergegeven in plaats van de daadwerkelijke foutboodschap. 

Deze PR zorgt ervoor dat alle soorten foutmeldingen correct worden afgehandeld en als leesbare tekst worden weergegeven aan de gebruiker.

## Test instructies
1. Log in op de applicatie
2. Controleer of de pagina correct laadt in plaats van op "Laden..." blijft staan
3. Controleer of foutmeldingen leesbaar worden weergegeven als tekst

Fixes #40